### PR TITLE
feat(provider): support hex input

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,6 +2,8 @@
 
 use crate::signature::{Signature, SignatureInput};
 use anyhow::{bail, Result};
+use num_bigint::BigUint;
+use num_traits::Num;
 use std::io::{self, Read};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -29,7 +31,40 @@ pub fn parse_signatures(content: &str) -> Result<Vec<Signature>> {
         Format::Csv => parse_csv(content)?,
     };
 
-    inputs.into_iter().map(Signature::try_from).collect()
+    inputs
+        .into_iter()
+        .map(|input| {
+            let normalized = normalize_input(input)?;
+            Signature::try_from(normalized)
+        })
+        .collect()
+}
+
+fn normalize_value(s: &str) -> Result<String> {
+    let trimmed = s.trim();
+    if let Some(hex_str) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        if hex_str.is_empty() {
+            bail!("Empty hex value after 0x prefix");
+        }
+        if !hex_str.chars().all(|c| c.is_ascii_hexdigit()) {
+            bail!("Invalid hex string: only hex digits allowed after 0x prefix");
+        }
+        let biguint = BigUint::from_str_radix(hex_str, 16)
+            .map_err(|e| anyhow::anyhow!("Failed to parse hex value: {}", e))?;
+        Ok(biguint.to_string())
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+fn normalize_input(mut input: SignatureInput) -> Result<SignatureInput> {
+    input.r = normalize_value(&input.r)?;
+    input.s = normalize_value(&input.s)?;
+    input.z = normalize_value(&input.z)?;
+    Ok(input)
 }
 
 const BOM: &str = "\u{FEFF}";
@@ -104,5 +139,77 @@ mod tests {
     fn test_invalid_json_error() {
         let result = parse_signatures("not json");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_normalize_value_decimal_passthrough() {
+        let result = normalize_value("12345").unwrap();
+        assert_eq!(result, "12345");
+    }
+
+    #[test]
+    fn test_normalize_value_hex_to_decimal() {
+        let result = normalize_value("0xff").unwrap();
+        assert_eq!(result, "255");
+    }
+
+    #[test]
+    fn test_normalize_value_hex_uppercase_prefix() {
+        let result = normalize_value("0XFF").unwrap();
+        assert_eq!(result, "255");
+    }
+
+    #[test]
+    fn test_normalize_value_hex_large() {
+        let result =
+            normalize_value("0x0f13c7c741321a95510ba98792bc9050efdce2e422be4610f162449adce92a47")
+                .unwrap();
+        assert_eq!(
+            result,
+            "6819641642398093696120236467967538361543858578256722584730163952555838220871"
+        );
+    }
+
+    #[test]
+    fn test_normalize_value_trims_whitespace() {
+        let result = normalize_value("  0xff  ").unwrap();
+        assert_eq!(result, "255");
+    }
+
+    #[test]
+    fn test_normalize_value_empty_hex_fails() {
+        let result = normalize_value("0x");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_normalize_value_invalid_hex_chars_fails() {
+        let result = normalize_value("0xGGGG");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_hex_json_signatures() {
+        let json = r#"[{
+            "r": "0x0f13c7c741321a95510ba98792bc9050efdce2e422be4610f162449adce92a47",
+            "s": "0x0b4cc3447a2793c4598e5829827f38c67f72e4c3d4688019cd94066b9e7df6b9",
+            "z": "0x0ab06bc2befd52cde3b2de709a642e437b8a7187cc28de72bd5aff4a896e047b"
+        }]"#;
+        let sigs = parse_signatures(json).unwrap();
+        assert_eq!(sigs.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_hex_csv_signatures() {
+        let csv = "r,s,z,pubkey\n0xff,0xfe,0xfd,";
+        let sigs = parse_signatures(csv).unwrap();
+        assert_eq!(sigs.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_mixed_hex_decimal_signatures() {
+        let json = r#"[{"r": "0xff", "s": "456", "z": "0xab"}]"#;
+        let sigs = parse_signatures(json).unwrap();
+        assert_eq!(sigs.len(), 1);
     }
 }

--- a/tests/fixtures/nonce_reuse_hex.json
+++ b/tests/fixtures/nonce_reuse_hex.json
@@ -1,0 +1,14 @@
+[
+  {
+    "r": "0x0f13c7c741321a95510ba98792bc9050efdce2e422be4610f162449adce92a47",
+    "s": "0x0b4cc3447a2793c4598e5829827f38c67f72e4c3d4688019cd94066b9e7df6b9",
+    "z": "0x0ab06bc2befd52cde3b2de709a642e437b8a7187cc28de72bd5aff4a896e047b",
+    "pubkey": null
+  },
+  {
+    "r": "0x0f13c7c741321a95510ba98792bc9050efdce2e422be4610f162449adce92a47",
+    "s": "0x44d4f1763d0910413d9e95e70b3f6066eec7a19890152c1b0c9aaf1e8aefac7f",
+    "z": "0xf08f973c808124b3e58d94e3d85efdd9038ad0834d62e7a1d8e128be992292eb",
+    "pubkey": null
+  }
+]

--- a/tests/hex_input.rs
+++ b/tests/hex_input.rs
@@ -1,0 +1,86 @@
+//! Integration tests for hex-encoded input values
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn test_analyze_nonce_reuse_hex_from_file() {
+    Command::cargo_bin("vusi")
+        .unwrap()
+        .arg("analyze")
+        .arg("tests/fixtures/nonce_reuse_hex.json")
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("nonce-reuse"))
+        .stdout(predicate::str::contains(
+            "62958994860637178871299877498639209302063112480839791435318431648713002718353",
+        ));
+}
+
+#[test]
+fn test_hex_json_output_matches_decimal() {
+    let hex_output = Command::cargo_bin("vusi")
+        .unwrap()
+        .arg("--json")
+        .arg("analyze")
+        .arg("tests/fixtures/nonce_reuse_hex.json")
+        .output()
+        .unwrap();
+
+    let dec_output = Command::cargo_bin("vusi")
+        .unwrap()
+        .arg("--json")
+        .arg("analyze")
+        .arg("tests/fixtures/nonce_reuse.json")
+        .output()
+        .unwrap();
+
+    assert_eq!(hex_output.status.code(), Some(1));
+    assert_eq!(dec_output.status.code(), Some(1));
+
+    let hex_json: serde_json::Value =
+        serde_json::from_slice(&hex_output.stdout).expect("hex output should be valid JSON");
+    let dec_json: serde_json::Value =
+        serde_json::from_slice(&dec_output.stdout).expect("decimal output should be valid JSON");
+
+    assert_eq!(
+        hex_json["vulnerabilities"][0]["recovered_key"]["private_key_decimal"],
+        dec_json["vulnerabilities"][0]["recovered_key"]["private_key_decimal"],
+        "Hex and decimal inputs should recover the same private key"
+    );
+}
+
+#[test]
+fn test_hex_from_stdin() {
+    let input = include_str!("fixtures/nonce_reuse_hex.json");
+    Command::cargo_bin("vusi")
+        .unwrap()
+        .arg("analyze")
+        .arg("-")
+        .write_stdin(input)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("nonce-reuse"));
+}
+
+#[test]
+fn test_mixed_hex_decimal_input() {
+    let input = r#"[
+      {"r": "0x0f13c7c741321a95510ba98792bc9050efdce2e422be4610f162449adce92a47",
+       "s": "5111069398017465712735164463809304352000044522184731945150717785434666956473",
+       "z": "0x0ab06bc2befd52cde3b2de709a642e437b8a7187cc28de72bd5aff4a896e047b"},
+      {"r": "6819641642398093696120236467967538361543858578256722584730163952555838220871",
+       "s": "0x44d4f1763d0910413d9e95e70b3f6066eec7a19890152c1b0c9aaf1e8aefac7f",
+       "z": "108808786585075507407446857551522706228868950080801424952567576192808212665067"}
+    ]"#;
+    Command::cargo_bin("vusi")
+        .unwrap()
+        .arg("analyze")
+        .arg("-")
+        .write_stdin(input)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "62958994860637178871299877498639209302063112480839791435318431648713002718353",
+        ));
+}


### PR DESCRIPTION
## Summary

Support `0x`-prefixed hex-encoded r/s/z values in JSON and CSV input files, so users don't need to manually convert from hex (the natural format in block explorers and tx parsers) to decimal.

Closes #12

## Changes
- Add `normalize_value` and `normalize_input` in `provider.rs` for hex→decimal conversion
- Normalize inputs before scalar parsing (no changes to math or signature layers)
- Add hex test fixture (`nonce_reuse_hex.json`) with same test vector as decimal fixture
- Add dedicated integration test file (`tests/hex_input.rs`) with 4 E2E tests
- Add 10 unit tests for normalization edge cases

## Testing
- [x] `cargo test --all-features` passes (71 tests)
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] Hex input produces identical recovered key as decimal input
- [x] Mixed hex/decimal within same file works
- [x] Edge cases: empty `0x`, invalid hex chars, whitespace trimming

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>