### PR TITLE
fix(nonce-reuse): verify recovered keys against pubkey and handle mixed s-normalization

### DIFF
--- a/src/attack/nonce_reuse.rs
+++ b/src/attack/nonce_reuse.rs
@@ -5,6 +5,8 @@ use crate::math::{
     recover_nonce, recover_private_key, scalar_to_decimal_string, scalar_to_hex_string,
 };
 use crate::signature::group_by_r_and_pubkey;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{AffinePoint, ProjectivePoint};
 
 pub struct NonceReuseAttack;
 
@@ -50,15 +52,47 @@ fn try_recover_pair(
     sig2: &Signature,
     pubkey: &Option<String>,
 ) -> Option<RecoveredKey> {
-    let k = recover_nonce(&sig1.z, &sig2.z, &sig1.s, &sig2.s)?;
-    let priv_key = recover_private_key(&sig1.r, &sig1.s, &sig1.z, &k)?;
+    if pubkey.is_some() {
+        // With pubkey: try both s2 polarities and verify d*G == pubkey.
+        // Handles mixed low-s/high-s normalization (BIP62).
+        for &s2 in &[sig2.s, -sig2.s] {
+            let k = match recover_nonce(&sig1.z, &sig2.z, &sig1.s, &s2) {
+                Some(k) => k,
+                None => continue,
+            };
+            let priv_key = match recover_private_key(&sig1.r, &sig1.s, &sig1.z, &k) {
+                Some(d) => d,
+                None => continue,
+            };
+            if verify_key_matches_pubkey(&priv_key, pubkey.as_ref().unwrap()) {
+                return Some(RecoveredKey {
+                    private_key: priv_key,
+                    private_key_decimal: scalar_to_decimal_string(&priv_key),
+                    private_key_hex: scalar_to_hex_string(&priv_key),
+                    pubkey: pubkey.clone(),
+                });
+            }
+        }
+        None
+    } else {
+        let k = recover_nonce(&sig1.z, &sig2.z, &sig1.s, &sig2.s)?;
+        let priv_key = recover_private_key(&sig1.r, &sig1.s, &sig1.z, &k)?;
+        Some(RecoveredKey {
+            private_key: priv_key,
+            private_key_decimal: scalar_to_decimal_string(&priv_key),
+            private_key_hex: scalar_to_hex_string(&priv_key),
+            pubkey: pubkey.clone(),
+        })
+    }
+}
 
-    Some(RecoveredKey {
-        private_key: priv_key,
-        private_key_decimal: scalar_to_decimal_string(&priv_key),
-        private_key_hex: scalar_to_hex_string(&priv_key),
-        pubkey: pubkey.clone(),
-    })
+fn verify_key_matches_pubkey(d: &Scalar, pubkey: &str) -> bool {
+    let computed = ProjectivePoint::GENERATOR * *d;
+    let affine: AffinePoint = computed.into();
+    let compressed = hex::encode(affine.to_encoded_point(true).as_bytes());
+    let uncompressed = hex::encode(affine.to_encoded_point(false).as_bytes());
+    let pk = pubkey.to_lowercase();
+    pk == compressed || pk == uncompressed
 }
 
 #[cfg(test)]
@@ -114,6 +148,106 @@ mod tests {
         let expected =
             "62958994860637178871299877498639209302063112480839791435318431648713002718353";
         assert_eq!(recovered.private_key_decimal, expected);
+    }
+
+    #[test]
+    fn test_nonce_reuse_recovery_with_pubkey_verification() {
+        use k256::elliptic_curve::ff::PrimeField;
+
+        let d = Scalar::from(42u64);
+        let pubkey_point = (ProjectivePoint::GENERATOR * d).to_affine();
+        let pubkey_hex = hex::encode(pubkey_point.to_encoded_point(true).as_bytes());
+
+        let k = Scalar::from(1000u64);
+        let z1 = Scalar::from(111u64);
+        let z2 = Scalar::from(222u64);
+
+        let kg = ProjectivePoint::GENERATOR * k;
+        let r = Scalar::from_repr_vartime(*kg.to_affine().to_encoded_point(false).x().unwrap())
+            .unwrap();
+
+        let k_inv = Option::<Scalar>::from(k.invert()).unwrap();
+        let s1 = k_inv * (z1 + r * d);
+        let s2 = k_inv * (z2 + r * d);
+
+        let sigs = vec![
+            Signature {
+                r,
+                s: s1,
+                z: z1,
+                pubkey: Some(pubkey_hex.clone()),
+                timestamp: None,
+                kp: None,
+            },
+            Signature {
+                r,
+                s: s2,
+                z: z2,
+                pubkey: Some(pubkey_hex.clone()),
+                timestamp: None,
+                kp: None,
+            },
+        ];
+
+        let attack = NonceReuseAttack;
+        let vulns = attack.detect(&sigs);
+        assert_eq!(vulns.len(), 1);
+
+        let recovered = attack.recover(&vulns[0]).unwrap();
+        assert_eq!(recovered.private_key, d);
+    }
+
+    #[test]
+    fn test_nonce_reuse_recovery_negated_s_with_pubkey() {
+        use k256::elliptic_curve::ff::PrimeField;
+
+        let d = Scalar::from(42u64);
+        let pubkey_point = (ProjectivePoint::GENERATOR * d).to_affine();
+        let pubkey_hex = hex::encode(pubkey_point.to_encoded_point(true).as_bytes());
+
+        let k = Scalar::from(1000u64);
+        let z1 = Scalar::from(111u64);
+        let z2 = Scalar::from(222u64);
+
+        let kg = ProjectivePoint::GENERATOR * k;
+        let r = Scalar::from_repr_vartime(*kg.to_affine().to_encoded_point(false).x().unwrap())
+            .unwrap();
+
+        let k_inv = Option::<Scalar>::from(k.invert()).unwrap();
+        let s1 = k_inv * (z1 + r * d);
+        let s2_raw = k_inv * (z2 + r * d);
+        // Negate s2 to simulate mixed low-s/high-s normalization (BIP62)
+        let s2_negated = -s2_raw;
+
+        let sigs = vec![
+            Signature {
+                r,
+                s: s1,
+                z: z1,
+                pubkey: Some(pubkey_hex.clone()),
+                timestamp: None,
+                kp: None,
+            },
+            Signature {
+                r,
+                s: s2_negated,
+                z: z2,
+                pubkey: Some(pubkey_hex.clone()),
+                timestamp: None,
+                kp: None,
+            },
+        ];
+
+        let attack = NonceReuseAttack;
+        let vulns = attack.detect(&sigs);
+        assert_eq!(vulns.len(), 1);
+
+        let recovered = attack.recover(&vulns[0]);
+        assert!(
+            recovered.is_some(),
+            "Should recover key even with negated s when pubkey is available"
+        );
+        assert_eq!(recovered.unwrap().private_key, d);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- When pubkey is available, verify recovered private key (`d*G == pubkey`) instead of returning unverified results
- Try both s₂ polarities (original and negated) to handle signatures with mixed BIP62 low-s/high-s normalization
- Without pubkey, behavior is unchanged (backward compatible)

## Problem

The nonce-reuse attack previously returned the first mathematically valid private key without verifying it against the known public key. This caused two issues:

1. **No verification**: A recovered key could be algebraically correct but wrong (e.g., if input data has errors)
2. **Mixed s-normalization**: When one signature's `s` was BIP62-canonicalized (low-s) and the other wasn't, the standard formula `k = (z₁-z₂)/(s₁-s₂)` yields the wrong nonce, and recovery silently fails

## Solution

When pubkey is present:
- Compute `d*G` and compare against the provided pubkey (compressed and uncompressed)
- Try both `s₂` and `-s₂`, verifying each candidate — only return the key that matches
- This follows the same pattern used by `biased_nonce::verify_candidate` and `polynonce::verify_key`

When pubkey is absent:
- Original unverified formula, no behavior change

## Tests

- `test_nonce_reuse_recovery_with_pubkey_verification` — EC-consistent signatures with known `d`, verifies correct key recovery
- `test_nonce_reuse_recovery_negated_s_with_pubkey` — Same setup but with `s₂` negated, proves s-polarity handling works
- All 73 existing tests pass, clippy clean