### PR TITLE
fix(provider): handle UTF-8 BOM in JSON and CSV parsing

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -137,6 +137,18 @@ mod tests {
     }
 
     #[test]
+    fn test_auto_detect_json_with_bom() {
+        let json = "\u{FEFF}[{\"r\":\"1\",\"s\":\"2\",\"z\":\"3\"}]";
+        assert_eq!(detect_format(json).unwrap(), Format::Json);
+    }
+
+    #[test]
+    fn test_auto_detect_csv_with_bom() {
+        let csv = "\u{FEFF}r,s,z\n1,2,3";
+        assert_eq!(detect_format(csv).unwrap(), Format::Csv);
+    }
+
+    #[test]
     fn test_invalid_json_error() {
         let result = parse_signatures("not json");
         assert!(result.is_err());

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -25,6 +25,7 @@ pub fn load_signatures(input: &str) -> Result<Vec<Signature>> {
 }
 
 pub fn parse_signatures(content: &str) -> Result<Vec<Signature>> {
+    let content = content.strip_prefix(BOM).unwrap_or(content);
     let format = detect_format(content)?;
     let inputs = match format {
         Format::Json => parse_json(content)?,
@@ -210,6 +211,20 @@ mod tests {
     fn test_parse_mixed_hex_decimal_signatures() {
         let json = r#"[{"r": "0xff", "s": "456", "z": "0xab"}]"#;
         let sigs = parse_signatures(json).unwrap();
+        assert_eq!(sigs.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_json_with_bom() {
+        let json = "\u{FEFF}[{\"r\":\"123\",\"s\":\"456\",\"z\":\"789\"}]";
+        let sigs = parse_signatures(json).unwrap();
+        assert_eq!(sigs.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_csv_with_bom() {
+        let csv = "\u{FEFF}r,s,z,pubkey\n123,456,789,\n";
+        let sigs = parse_signatures(csv).unwrap();
         assert_eq!(sigs.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
I hit this while validating fixture ingestion from exported files. `detect_format` already tolerated UTF-8 BOM, but actual parsing still used raw content, so BOM-prefixed input could be detected correctly and then fail in `serde_json` or CSV deserialization.

## Changes
- Strip UTF-8 BOM at the start of `parse_signatures` before dispatching to JSON/CSV parsers
- Add a regression test for BOM-prefixed JSON input
- Add a regression test for BOM-prefixed CSV input
- Add direct `detect_format` tests for BOM-prefixed JSON and CSV input

## Testing
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo build --release`

## Related Issues
Closes #25