### PR TITLE
fix(cli): use attack-specific recovery failure reasons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,11 +229,7 @@ fn format_output(
                 }
                 _ => "recovery did not produce a valid key",
             };
-            (
-                "unrecoverable".to_string(),
-                Some(reason.to_string()),
-                None,
-            )
+            ("unrecoverable".to_string(), Some(reason.to_string()), None)
         };
 
         vuln_outputs.push(VulnerabilityOutput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,9 +221,17 @@ fn format_output(
                 }),
             )
         } else {
+            let reason = match vuln.attack_type.as_str() {
+                "nonce-reuse" => "all signature pairs have identical s values",
+                "polynonce" => "elimination polynomial roots did not produce a valid key",
+                _ if vuln.attack_type.starts_with("biased-nonce") => {
+                    "lattice reduction did not yield the private key"
+                }
+                _ => "recovery did not produce a valid key",
+            };
             (
                 "unrecoverable".to_string(),
-                Some("all pairs have s1 == s2".to_string()),
+                Some(reason.to_string()),
                 None,
             )
         };


### PR DESCRIPTION
Recovery failure always reported "all pairs have s1 == s2" regardless of which attack was running. That message only makes sense for nonce-reuse - for polynonce or biased-nonce it's actively misleading.

Now each attack type gets its own reason string when recovery fails.

Closes #21