### PR TITLE
fix(polynonce): reject unsupported degree parameter

### DIFF
--- a/src/attack/polynonce.rs
+++ b/src/attack/polynonce.rs
@@ -15,6 +15,10 @@ pub struct PolynonceAttack {
 
 impl PolynonceAttack {
     pub fn new(degree: usize) -> Self {
+        assert!(
+            degree == 1,
+            "only linear polynonce (degree=1) is implemented, got degree={degree}"
+        );
         Self { degree }
     }
 
@@ -383,6 +387,12 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    #[should_panic(expected = "only linear polynonce")]
+    fn test_degree_above_1_panics() {
+        PolynonceAttack::new(2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,12 @@ fn run(cli: Cli) -> Result<bool> {
                 }
                 #[cfg(feature = "polynonce")]
                 "polynonce" => {
+                    if _polynonce_degree != 1 {
+                        anyhow::bail!(
+                            "Only degree=1 (linear) is supported for polynonce attack, got {}",
+                            _polynonce_degree
+                        );
+                    }
                     let attack = PolynonceAttack::new(_polynonce_degree);
                     let vulns = attack.detect(&signatures);
                     (vulns, Box::new(attack))


### PR DESCRIPTION
`PolynonceAttack::new(degree)` accepted any value, but the elimination polynomial math is hardcoded for linear nonce relationships (degree=1). Setting `--degree 2` would loosen the detection filter without actually implementing quadratic recovery, so the tool would report vulnerabilities it can't exploit.

Constructor now panics on degree != 1, and the CLI validates before construction with a proper error message.

Closes #20