### PR TITLE
chore(deps): remove unused thiserror dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "ripemd",
  "serde",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror",
  "toml",
 ]
 
@@ -927,31 +927,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1071,7 +1051,6 @@ dependencies = [
  "rug",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ num-traits = "0.2"
 
 # Error handling
 anyhow = "1.0"
-thiserror = "1.0"
 
 # CLI
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
`thiserror` was listed in Cargo.toml but never imported anywhere in the codebase. All error handling goes through `anyhow` directly.